### PR TITLE
feat: #5 Add pull request template to the repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,30 @@
+## What does this Pull Request do?
+
+Briefly describe what this PR is about here.
+
+## Related Issues
+
+Mention the issues in this MR. For example:
+- Issue #3 (GitHub should automatically create a link from it)
+
+## Design decision
+
+Describe what design decisions were made and why.
+Describe alternative solutions that you've considered.
+
+## Steps to manually check the changes
+
+Describe the necessary steps to test this MR.
+
+## Author's checklist
+
+- [ ] My changes are covered by tests
+- [ ] My changes are documented, existing documentation is updated
+- [ ] My changes follow our code quality guidelines
+
+## Review checklist
+
+- [ ] Pull request title contains the correct ticket number
+- [ ] Pull request is opened against the correct base branch
+- [ ] Pull request description matches the changes in the code
+- [ ] There is no apparent way to improve the performance & design of the new code


### PR DESCRIPTION
## What does this Pull Request do?

Adds pull request template, this would ensure that all PR looks similar

## Related Issues

- Issue #5 

## Steps to manually check the changes

Currently there is no. Reasoning - GitHub will start using the PR template only after this PR is merged into master branch. After this PR is merged, we should see that when new PR is opened, it has this pre-defined template already setup.

## Author's checklist

- [ ] My changes are covered by tests
- [ ] My changes are documented, existing documentation is updated
- [x] My changes follow our code quality guidelines

## Review checklist

- [ ] Pull request title contains the correct ticket number
- [ ] Pull request is opened against the correct base branch
- [ ] Pull request description matches the changes in the code
- [ ] There is no apparent way to improve the performance & design of the new code
